### PR TITLE
copy operation values coming from traces

### DIFF
--- a/crossbeam/algorithm/synthesis.py
+++ b/crossbeam/algorithm/synthesis.py
@@ -164,11 +164,10 @@ def update_with_better_value(result_value, all_value_dict, all_values, model,
           old_value, old_value.expression(), old_value.get_weight()))
 
 
-def copy_operation_value(value):
-  if isinstance(value, value_module.OperationValue):
-    return value_module.OperationValue(value.values, value.operation, [copy_operation_value(v) for v in value.arg_values])
-  else:
-    return value
+def copy_operation_value(value, all_values, all_value_dict):
+  assert isinstance(value, value_module.OperationValue)
+  arg_values = [all_values[all_value_dict[v]] for v in value.arg_values]
+  return value_module.OperationValue(value.values, value.operation, arg_values)
 
 
 def synthesize(task, domain, model, device,
@@ -321,7 +320,7 @@ def synthesize(task, domain, model, device,
         if include_as_train(trace_in_beam):  # construct training example
           if trace_in_beam < 0:  # true arg not found
             true_args = []
-            true_val = copy_operation_value(trace[0])
+            true_val = copy_operation_value(trace[0], all_values, all_value_dict)
             if not true_val in all_value_dict:
               all_value_dict[true_val] = len(all_values)
               all_values.append(true_val)
@@ -472,7 +471,7 @@ def batch_synthesize(tasks, domain, model, device, traces=None, max_weight=10, k
           if include_as_train(trace_in_beam):
             if trace_in_beam < 0:  # true arg not found
               true_args = []
-              true_val = copy_operation_value(trace[0])
+              true_val = copy_operation_value(trace[0], all_values, all_value_dict)
               vid = get_or_add_value(true_val, all_values, all_value_dict)
               value_indices[t_idx].append(vid)
               true_arg_vals = true_val.arg_values


### PR DESCRIPTION
Here's an example scenario that illustrates the bug.

Note that within 1 data generation search, we choose multiple values to serve as outputs, all coming from the same inputs and all using shared values constructed during the search.

Input `in1`: ['abc', 'abc']
Input `in2`: ['1', '2']

Task 1: `Upper(Concatenate(Rept(in1, 2), in2))`: ['ABCABC1', 'ABCABC2']
Constant extracted from the outputs: 'ABCABC'

During search, we add the trace element `Rept(in1, 2)` with weight 3 to the set of values. Later we find that it can be written with weight 2 `Lower('ABCABC')` using the constant 'ABCABC' extracted only for this task (due to this task's outputs), and we update the value accordingly. Unfortunately this change persists within the task object's solution value, since the value we updated is actually a subtree of the solution.

Task 2: `Concatenate(in2, Rept(in1, 2))`: ['1abcabc', '2abcabc']
Constant extracted from the outputs: 'abcabc'

Then, we try task 2 which comes from the same data generation search. The subtree `Rept(in1, 2)` was also in the previous task, and it is actually the same object as in the previous task. Hence, it has since been updated to `Lower('ABCABC')`. When we try to add this as a trace value to the set of values, we notice that we don't have the argument 'ABCABC' since it was only a constant for Task 1, not for this current Task 2. This triggers the assertion error.


The fix is to prevent trace values from being updated, by making a copy of the trace value and inserting the copy into all_values, where the copy may be updated later without damaging the original trace value, and in particular, without damaging other tasks.